### PR TITLE
fix(ci): add permissions to semantic release

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -36,7 +36,7 @@ jobs:
       packages: write
     concurrency:
       # Only one release job at a time. Strictly sequential.
-      group: release
+      group: release-${{ github.event.number || github.ref }}
     runs-on: ubuntu-latest
     needs:
       - build
@@ -51,7 +51,7 @@ jobs:
           node-version: lts/*
       - run: npm clean-install
       - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npx semantic-release
   success:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration to improve the build and deployment process, addressing problems regarding the concurrency of release jobs and the permissions of semantic release to push to the main branch.